### PR TITLE
Update routes to reflect new commute itinerary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+# Makefile helpers for the ratp-time-app project
+
+APP_DIR := ratp-time-app
+
+.PHONY: install run
+
+install:
+	npm install --prefix $(APP_DIR)
+
+run: install
+	npm run dev --prefix $(APP_DIR)

--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,4 @@ install:
 	npm install --prefix $(APP_DIR)
 
 run: install
-	npm run dev --prefix $(APP_DIR)
+	NODE_OPTIONS="--max-http-header-size=65536" npm run dev --prefix $(APP_DIR)

--- a/ratp-time-app/README.md
+++ b/ratp-time-app/README.md
@@ -10,8 +10,8 @@ Live site (if configured): https://ratp.thefrenchartist.dev
 - Manual refresh button to bypass cache
 - Pages:
   - Auto — selects Forwards before noon and Return after noon (Europe/Paris)
-  - Forwards — morning commute directions (Chevaleret → Étoile, Place d’Italie → La Courneuve)
-  - Return — evening commute directions (Chaussée d’Antin → Place d’Italie, Place d’Italie → Chevaleret)
+  - Forwards — morning commute directions (Chevaleret → Bercy, Bercy → Madeleine, Madeleine → Trinité – d’Estienne d’Orves)
+  - Return — evening commute directions (Trinité – d’Estienne d’Orves → Madeleine, Madeleine → Bercy, Bercy → Chevaleret)
  - Polished About page with animated cards and subtle effects
 
 ## Monitored Lines and Stops
@@ -20,17 +20,27 @@ Configured in `src/pages/ForwardsPage.jsx` and `src/pages/ReturnTripPage.jsx`:
 
 - Metro 6
   - LineRef: `STIF:Line::C01376:`
-  - Forwards → MonitoringRef: `STIF:StopPoint:Q:22174:` (Chevaleret)
-  - Return → MonitoringRef: `STIF:StopPoint:Q:463003:` (Place d’Italie alternative platform)
-  - Destination filter: contains “Charles de Gaulle – Étoile”
-
-- Metro 7
-  - LineRef: `STIF:Line::C01377:`
-  - Forwards → MonitoringRef: `STIF:StopPoint:Q:463026:` (Place d’Italie)
-  - Return → MonitoringRefs: `STIF:StopPoint:Q:463145:` and `STIF:StopPoint:Q:22388:` (Chaussée d’Antin – La Fayette platforms)
+  - Forwards → MonitoringRefs: `STIF:StopPoint:Q:22174:` and `STIF:StopPoint:Q:463147:` (Chevaleret platforms toward Nation/Bercy)
+  - Return → MonitoringRefs: `STIF:StopPoint:Q:463128:` and `STIF:StopPoint:Q:22178:` (Bercy platforms toward Charles de Gaulle – Étoile)
   - Destination filters:
-    - Forwards: contains “La Courneuve – 8 Mai 1945” (direction serving Chaussée d’Antin)
-    - Return: contains “Italie”, “Ivry”, or “Villejuif”
+    - Forwards: contains “Nation”
+    - Return: contains “Charles de Gaulle – Étoile”
+
+- Metro 14
+  - LineRef: `STIF:Line::C01384:`
+  - Forwards → MonitoringRef: `STIF:StopPoint:Q:21957:` (Bercy toward Saint-Denis – Pleyel)
+  - Return → MonitoringRef: `STIF:StopPoint:Q:21961:` (Madeleine toward Aéroport d’Orly)
+  - Destination filters:
+    - Forwards: contains “Saint-Denis – Pleyel”
+    - Return: contains “Aéroport d’Orly”
+
+- Metro 12
+  - LineRef: `STIF:Line::C01382:`
+  - Forwards → MonitoringRef: `STIF:StopPoint:Q:463081:` (Madeleine toward Mairie d’Aubervilliers)
+  - Return → MonitoringRef: `STIF:StopPoint:Q:463317:` (Trinité – d’Estienne d’Orves toward Mairie d’Issy)
+  - Destination filters:
+    - Forwards: contains “Mairie d’Aubervilliers”
+    - Return: contains “Mairie d’Issy”
 
 ## Tech Stack
 - React 18 + Vite 5
@@ -82,7 +92,7 @@ Validate with SIRI Stop Monitoring
 `curl -H "Accept: application/json" -H "apikey: <YOUR_API_KEY>" \
   "https://prim.iledefrance-mobilites.fr/marketplace/stop-monitoring?MonitoringRef=<STOPPOINT_ID>&LineRef=<LINE_REF>" | jq`
 
-You should see `MonitoredStopVisit` entries with matching `DestinationName` (e.g., “Charles de Gaulle – Étoile” for M6, “La Courneuve – 8 Mai 1945” for M7). If empty, try the other platform ID for the station or remove the `LineRef` parameter to test.
+You should see `MonitoredStopVisit` entries with matching `DestinationName` (e.g., “Nation” for M6, “Saint-Denis – Pleyel” for M14, “Mairie d’Aubervilliers” for M12). If empty, try the other platform ID for the station or remove the `LineRef` parameter to test.
 
 ### API Key and Security Note
 The code currently assembles an API key string inside `src/components/TransportDisplay.jsx` for the IDFM API. Exposing API keys in client code is not secure for production.

--- a/ratp-time-app/package-lock.json
+++ b/ratp-time-app/package-lock.json
@@ -69,6 +69,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1322,6 +1323,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1665,6 +1667,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001737",
         "electron-to-chromium": "^1.5.211",
@@ -2207,6 +2210,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.35.0.tgz",
       "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3519,6 +3523,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
       "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
       "dev": true,
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4215,6 +4220,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.0",
@@ -4421,6 +4427,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4432,6 +4439,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5289,6 +5297,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
       "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/ratp-time-app/src/pages/AboutPage.jsx
+++ b/ratp-time-app/src/pages/AboutPage.jsx
@@ -63,11 +63,22 @@ function AboutPage() {
           <Card title="Lines and stops" icon="map" index={2}>
             <ul className="list-disc list-outside pl-4">
               <li>
-                Metro 6 — Chevaleret → filter for trains toward “Charles de Gaulle – Étoile”
+                Metro 6 — Chevaleret → filter for trains toward “Nation” (Bercy-bound)
               </li>
               <li>
-                Metro 7 — Place d’Italie → filter for trains toward “La Courneuve – 8 Mai 1945”
-                (direction that serves Chaussée d’Antin – La Fayette)
+                Metro 14 — Bercy → filter for trains toward “Saint-Denis – Pleyel” (Madeleine-bound)
+              </li>
+              <li>
+                Metro 12 — Madeleine → filter for trains toward “Mairie d’Aubervilliers” (Trinité – d’Estienne d’Orves-bound)
+              </li>
+              <li>
+                Metro 12 — Trinité – d’Estienne d’Orves → filter for trains toward “Mairie d’Issy” (Madeleine-bound)
+              </li>
+              <li>
+                Metro 14 — Madeleine → filter for trains toward “Aéroport d’Orly” (Bercy-bound)
+              </li>
+              <li>
+                Metro 6 — Bercy → filter for trains toward “Charles de Gaulle – Étoile” (Chevaleret-bound)
               </li>
             </ul>
           </Card>

--- a/ratp-time-app/src/pages/ForwardsPage.jsx
+++ b/ratp-time-app/src/pages/ForwardsPage.jsx
@@ -3,19 +3,15 @@ import React from 'react';
 import TransportDisplay from '../components/TransportDisplay';
 
 function ForwardsPage() {
-  // IDFM SIRI identifiers (validated):
-  // - Metro 6 (LineRef) + Chevaleret stop point (MonitoringRef)
-  // - Metro 7 (LineRef) + Place d’Italie stop point (MonitoringRef)
+  // IDFM SIRI identifiers for the morning itinerary:
+  // - Metro 6 (Chevaleret eastbound toward Nation)
   const metroLines = {
-    // Key is the label shown in the UI, value is the SIRI LineRef.
-    // Per perimetre-des-donnees-tr-disponibles-plateforme-idfm.csv (Chevaleret, Metro 6)
     'M6': 'STIF:Line::C01376:',
   };
 
   const metroMonitoringRefs = {
-    // From perimetre-des-donnees-tr-disponibles-plateforme-idfm.csv
-    // Chevaleret StopPoint (platform): STIF:StopPoint:Q:22174:
-    'M6': 'STIF:StopPoint:Q:22174:',
+    // Include both Chevaleret platforms; filter keeps only Nation-bound departures.
+    'M6': ['STIF:StopPoint:Q:22174:', 'STIF:StopPoint:Q:463147:'],
   };
 
   return (
@@ -23,19 +19,28 @@ function ForwardsPage() {
       <TransportDisplay
         metroLines={metroLines}
         metroMonitoringRefs={metroMonitoringRefs}
-        destinationPattern={/charles\s+de\s+gaulle/i}
-        title={"Metro 6 — Chevaleret → Charles de Gaulle – Étoile"}
+        destinationPattern={/nation/i}
+        title={"Metro 6 — Chevaleret → Bercy"}
       />
 
       <div className="spacer-24" />
 
       <TransportDisplay
-        metroLines={{ 'M7': 'STIF:Line::C01377:' }}
-        // Place d’Italie (Line 7) StopPoint candidates include Q:22365 and Q:463026; using Q:463026
-        metroMonitoringRefs={{ 'M7': 'STIF:StopPoint:Q:463026:' }}
-        // Filter trains heading toward La Courneuve – 8 Mai 1945 (direction that serves Chaussée d’Antin)
-        destinationPattern={/courneuve/i}
-        title={"Metro 7 — Place d’Italie → Chaussée d’Antin – La Fayette"}
+        metroLines={{ 'M14': 'STIF:Line::C01384:' }}
+        // Bercy (Line 14) toward Madeleine and Saint-Denis – Pleyel
+        metroMonitoringRefs={{ 'M14': 'STIF:StopPoint:Q:21957:' }}
+        destinationPattern={/saint[-\s]*denis|pleyel/i}
+        title={"Metro 14 — Bercy → Madeleine"}
+      />
+
+      <div className="spacer-24" />
+
+      <TransportDisplay
+        metroLines={{ 'M12': 'STIF:Line::C01382:' }}
+        // Madeleine (Line 12) toward Trinité – d’Estienne d’Orves and Mairie d'Aubervilliers
+        metroMonitoringRefs={{ 'M12': 'STIF:StopPoint:Q:463081:' }}
+        destinationPattern={/aubervilliers/i}
+        title={"Metro 12 — Madeleine → Trinité – d’Estienne d’Orves"}
       />
     </div>
   );

--- a/ratp-time-app/src/pages/ReturnTripPage.jsx
+++ b/ratp-time-app/src/pages/ReturnTripPage.jsx
@@ -5,26 +5,32 @@ import TransportDisplay from '../components/TransportDisplay';
 function ReturnTripPage() {
   return (
     <div className="container">
-      {/* Metro 7 — Chaussée d’Antin → Place d’Italie (southbound) */}
       <TransportDisplay
-        metroLines={{ 'M7': 'STIF:Line::C01377:' }}
-        // Chaussée d'Antin - La Fayette (Line 7) platforms (both directions listed to ensure coverage)
-        metroMonitoringRefs={{ 'M7': ['STIF:StopPoint:Q:463145:', 'STIF:StopPoint:Q:22388:'] }}
-        // Trains going to Place d'Italie continue toward Villejuif – Louis Aragon or Mairie d'Ivry
-        destinationPattern={/italie|ivry|villejuif/i}
-        title={"Metro 7 — Chaussée d’Antin – La Fayette → Place d’Italie"}
+        metroLines={{ 'M12': 'STIF:Line::C01382:' }}
+        // Trinité – d’Estienne d’Orves (Line 12) toward Madeleine and Mairie d'Issy
+        metroMonitoringRefs={{ 'M12': 'STIF:StopPoint:Q:463317:' }}
+        destinationPattern={/mairie\s+d['’]?issy/i}
+        title={"Metro 12 — Trinité – d’Estienne d’Orves → Madeleine"}
       />
 
       <div className="spacer-24" />
 
-      {/* Metro 6 — Place d’Italie → Chevaleret (toward Charles de Gaulle – Étoile) */}
+      <TransportDisplay
+        metroLines={{ 'M14': 'STIF:Line::C01384:' }}
+        // Madeleine (Line 14) heading back to Bercy toward Aéroport d'Orly
+        metroMonitoringRefs={{ 'M14': 'STIF:StopPoint:Q:21961:' }}
+        destinationPattern={/orly/i}
+        title={"Metro 14 — Madeleine → Bercy"}
+      />
+
+      <div className="spacer-24" />
+
       <TransportDisplay
         metroLines={{ 'M6': 'STIF:Line::C01376:' }}
-        // Try the alternative quai at Place d'Italie for Line 6
-        metroMonitoringRefs={{ 'M6': 'STIF:StopPoint:Q:463003:' }}
-        // Trains toward Chevaleret are heading to Charles de Gaulle – Étoile
+        // Bercy (Line 6) toward Chevaleret and Charles de Gaulle – Étoile
+        metroMonitoringRefs={{ 'M6': ['STIF:StopPoint:Q:463128:', 'STIF:StopPoint:Q:22178:'] }}
         destinationPattern={/etoile|charles\s*de\s*gaulle/i}
-        title={"Metro 6 — Place d’Italie → Chevaleret"}
+        title={"Metro 6 — Bercy → Chevaleret"}
       />
     </div>
   );

--- a/ratp-time-app/src/pages/ReturnTripPage.jsx
+++ b/ratp-time-app/src/pages/ReturnTripPage.jsx
@@ -29,7 +29,7 @@ function ReturnTripPage() {
         metroLines={{ 'M6': 'STIF:Line::C01376:' }}
         // Bercy (Line 6) toward Chevaleret and Charles de Gaulle – Étoile
         metroMonitoringRefs={{ 'M6': ['STIF:StopPoint:Q:463128:', 'STIF:StopPoint:Q:22178:'] }}
-        destinationPattern={/etoile|charles\s*de\s*gaulle/i}
+        destinationPattern={/(?:é|e)toile|charles\s*de\s*gaulle/i}
         title={"Metro 6 — Bercy → Chevaleret"}
       />
     </div>


### PR DESCRIPTION
## Summary
- update the Forwards page to monitor Metro 6, 14, and 12 for the Chevaleret → Trinité – d’Estienne d’Orves morning route
- adjust the Return page and About page copy to reflect the Madeleine → Chevaleret evening journey via Metro 12, 14, and 6
- refresh the README Monitored Lines section with the new stop identifiers and destination filters

## Testing
- npm run lint *(fails: existing unused React import and prop-types errors)*

------
https://chatgpt.com/codex/tasks/task_e_68f3843868d08320aaae39e3c56fb7a7